### PR TITLE
merging 2016 refactor branch

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,5 @@
+fixtures:
+  symlinks:
+    pe_winagent: #{source_dir}
+  repositories:
+    pe_repo: https://github.com/GeoffWilliams/geoffwilliams-pe_repo.git

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 ##Description
 
-pe_winagent is a module that riffs on the Linux 'curl' [installation method for Puppet Enterprise](https://docs.puppetlabs.com/pe/latest/install_agents.html) to create a more fluid installation process for Windows nodes.  It currently supports Puppet Enterprise 3.3, 3.7, 3.8, 2015.x and 2016.x.
+pe_winagent is a module that helps with automating the installation process of Puppet Enterprise on Windows servers by riffing on the Linux 'curl' [installation method for Puppet Enterprise](https://docs.puppetlabs.com/pe/latest/install_agents.html) installation process. It currently supports Puppet Enterprise 3.3, 3.7, 3.8, 2015.x and 2016.x.
 
-The module runs on the master and stores the Windows puppet agent MSI for installation.  The module also provides a PowerShell module you can include on your Windows builds to automate or kick off installation on demand.
+The module runs on the master and stores the Windows puppet agent MSI for installation.  The module also provides a PowerShell module to include in your Windows images to automate or kick off installation on demand.
 
 ##Installation
 
@@ -19,7 +19,7 @@ If you're seeing this from the Puppet Forge, a simple `puppet module install sou
 
 ### pe_winagent
 
-Apply the pe_winagent class to your puppetmaster. and any compilers.  This will download the appropriate puppet agent MSI into the packages/current/windows directory.
+Apply the pe_winagent class to your puppetmaster and any compilers.  This will download the appropriate puppet agent MSI into the packages/current/windows directory.
 
 #### Parameters
 
@@ -28,7 +28,7 @@ Apply the pe_winagent class to your puppetmaster. and any compilers.  This will 
 
 ### pe_winagent::powershell_host
 
-Apply the pe_winagent::powershell_host class to a Windows server to serve as the PowerShell host,  i.e. the server you would remotely execute PowerShell from.  This server must have a minimum of .NET 4.5 and Windows Management Framework 4.0 installed.
+This class deploys the PowerShell module to a Windows host, which is good for using a PowerShell host to remotely manage installation and upgrade of puppet agents across your Windows infrastructure.  This server must have a minimum of .NET 4.5 and Windows Management Framework 4.0 installed.  It can also be used to update the PowerShell module across your infrastructure when new releases of this puppet module are released.
 	
 ---
 	
@@ -39,21 +39,17 @@ This is a PowerShell module with a few basic functions to install puppet either 
 #### Cmdlets
 
 	Test-PuppetInstall    = Verify the PS module is working and if a PE agent is installed.
-	Install-Puppet        = Installs the puppet agent from a specified master.
-		
-#### Usage
+	Install-Puppet        = Installs the puppet agent from a specified master.  Parameters below:		
 
-** Parameters **
+	  Local options:
+	  -Local			= Install Puppet agent locally
+	  -Master			= Specify the Puppet Master which contains the MSI/install script.
+	  -CertName		= Specify your FQDN for puppet registration.
+	  -CAServer		= Specify a CA server for the puppet agent.
 
-	Local options:
-	-Local			= Install Puppet agent locally
-	-Master			= Specify the Puppet Master which contains the MSI/install script.
-	-CertName		= Specify your FQDN for puppet registration.
-	-CAServer		= Specify a CA server for the puppet agent.
-
-	Remote options:
-	-Remote			= Install Puppet agent remotely
-	-ComputerList		= Either a single hostname or a CSV list of hosts to install remotely.
+	  Remote options:
+	  -Remote			= Install Puppet agent remotely
+	  -ComputerList		= Either a single hostname or a CSV list of hosts to install remotely.
 
 *Note: To install Puppet remotely you need to have PSRemoting enabled and have TrustedHosts configured.  If you don't know how to get started on that, you may want to consider the local method for now.*
 		
@@ -69,6 +65,10 @@ This is a PowerShell module with a few basic functions to install puppet either 
 **Upgrade the current node:**
 
 	Install-Puppet -Local -Master my.puppetmaster.local
+
+**Install Puppet with a different hostname**
+
+	Install-Puppet -Master my.puppetmaster.local -CertName windowspuppetbox.iscool.local
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -29,43 +29,30 @@ Apply the pe_winagent class to your puppetmaster. and any compilers.  This will 
 ### pe_winagent::powershell_host
 
 Apply the pe_winagent::powershell_host class to a Windows server to serve as the PowerShell host,  i.e. the server you would remotely execute PowerShell from.  This server must have a minimum of .NET 4.5 and Windows Management Framework 4.0 installed.
-
----
-
-### PowerShell Script: installpuppet.ps1
-
-This script will allow you to install Puppet locally.  Good for embedding into your provisioning scripts if you have a static Puppetmaster or as a one and done script for getting the most recent version from the Puppetmaster and upgrading the agent.
-
-#### Parameters
-
-	temp		= set a temporary directory, defaults to c:\temp
-	master		= the hostname of your puppetmaster
-
-#### Usage
-
-**Install Puppet**
-
-	./installpuppet.ps1 -Master mypuppetmaster.internet.local
 	
 ---
 	
 ### PowerShell Module: PuppetAgent
 
-This is a powershell module with a few basic functions to install puppet either locally or remotely.  If you already have puppet installed on Windows hosts, this would be a good way to ugprade.
+This is a PowerShell module with a few basic functions to install puppet either locally or remotely.  If you already have puppet installed on Windows hosts, this would be a good way to ugprade.
 
 #### Cmdlets
 
-	Test-Puppet    = Verify if you are a Jedi.
-	Get-Puppet     = Return the current version of the Puppet Agent installed.
-	Install-Puppet = Installs the puppet agent (retreived from the puppetmaster).
+	Test-PuppetInstall    = Verify the PS module is working and if a PE agent is installed.
+	Install-Puppet        = Installs the puppet agent from a specified master.
 		
 #### Usage
 
 ** Parameters **
 
-	-Remote			= Install Puppet agent remotely
+	Local options:
 	-Local			= Install Puppet agent locally
 	-Master			= Specify the Puppet Master which contains the MSI/install script.
+	-CertName		= Specify your FQDN for puppet registration.
+	-CAServer		= Specify a CA server for the puppet agent.
+
+	Remote options:
+	-Remote			= Install Puppet agent remotely
 	-ComputerList		= Either a single hostname or a CSV list of hosts to install remotely.
 
 *Note: To install Puppet remotely you need to have PSRemoting enabled and have TrustedHosts configured.  If you don't know how to get started on that, you may want to consider the local method for now.*
@@ -92,6 +79,18 @@ This is a powershell module with a few basic functions to install puppet either 
 * More importantly than Windows version is the Powershell version.  The scripts were written and tested under Powershell 4.0.  The check your version, from a Powershell prompt type `$PSVersionTable.PSVersion`.  If your Major version is less than 4, [you may want to upgrade](https://www.microsoft.com/en-us/download/details.aspx?id=40855).
 
 ### Changelog
+
+**v2.1.0**
+
+- Fixed pathing issue to support Puppet Enterprise 2016.
+- Fixed issue with local installation not passing `-CertName` or `-CAServer` parameters.
+- Added a trap to kill the install process if the server can't be resolved or install script cannot be found.
+- Added exit codes which end up being rather important when automating this thing.
+- Renamed `Test-Puppet` to `Test-PuppetInstall`, which now returns that a) this module is here and b) if Puppet Enterprise is already installed (and what version).
+- Removed the stubs for Uninstall-Puppet and Get-Puppet.
+- Removed the documentation for using install.ps1 as a standalone script. That's as logical as using install.bash and copying it everywhere.
+- Added logic to grab the non-x64 msi so 3.3 support technically exists now.
+
 
 **v2.0.3**
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 ##Description
 
-pe_winagent is a module that riffs on the Linux 'curl' [installation method for Puppet Enterprise](https://docs.puppetlabs.com/pe/latest/install_agents.html) to create a more fluid installation process for Windows nodes.  
+pe_winagent is a module that riffs on the Linux 'curl' [installation method for Puppet Enterprise](https://docs.puppetlabs.com/pe/latest/install_agents.html) to create a more fluid installation process for Windows nodes.  It currently supports Puppet Enterprise 3.3, 3.7, 3.8, 2015.x and 2016.x.
 
-The module runs on the master and co-opts the pe_repo class and space to retain the current .msi for Puppet Enterprise.  Once the MSI is mounted there are two options for installing, a local script or a powershell module for remote installation of Windows nodes.
+The module runs on the master and stores the Windows puppet agent MSI for installation.  The module also provides a PowerShell module you can include on your Windows builds to automate or kick off installation on demand.
 
 ##Installation
 
@@ -89,7 +89,7 @@ This is a PowerShell module with a few basic functions to install puppet either 
 - Renamed `Test-Puppet` to `Test-PuppetInstall`, which now returns that a) this module is here and b) if Puppet Enterprise is already installed (and what version).
 - Removed the stubs for Uninstall-Puppet and Get-Puppet.
 - Removed the documentation for using install.ps1 as a standalone script. That's as logical as using install.bash and copying it everywhere.
-- Added logic to grab the non-x64 msi so 3.3 support technically exists now.
+- Puppet Enterprise 3.3 is supported now.
 
 
 **v2.0.3**

--- a/README.md
+++ b/README.md
@@ -82,14 +82,13 @@ This is a PowerShell module with a few basic functions to install puppet either 
 
 **v2.1.0**
 
-- Fixed pathing issue to support Puppet Enterprise 2016.
+- Puppet Enterprise 2016.x is supported now.
+- Puppet Enterprise 3.3 is supported now.
 - Fixed issue with local installation not passing `-CertName` or `-CAServer` parameters.
 - Added a trap to kill the install process if the server can't be resolved or install script cannot be found.
-- Added exit codes which end up being rather important when automating this thing.
 - Renamed `Test-Puppet` to `Test-PuppetInstall`, which now returns that a) this module is here and b) if Puppet Enterprise is already installed (and what version).
 - Removed the stubs for Uninstall-Puppet and Get-Puppet.
 - Removed the documentation for using install.ps1 as a standalone script. That's as logical as using install.bash and copying it everywhere.
-- Puppet Enterprise 3.3 is supported now.
 
 
 **v2.0.3**

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,1 @@
+require 'puppetlabs_spec_helper/rake_tasks'

--- a/files/PuppetAgent.psm1
+++ b/files/PuppetAgent.psm1
@@ -1,4 +1,6 @@
 #PuppetAgent.psm1
+$ModuleVersion = "2.1.0"
+
 Function Install-PuppetLocal {
 	Param(
 	  [Switch]$Local,
@@ -9,7 +11,7 @@ Function Install-PuppetLocal {
 	  [String]$CAServer = $Master,
     [String]$Temp = "C:\Temp"
 	)
-
+  
   If (!(Test-Path $Temp)) { New-Item -Type Directory -Path $Temp -Force}
 
   Trap {
@@ -136,7 +138,11 @@ Function Install-Puppet {
 }
 
 function Test-PuppetInstall {
-	Write-Host "PE WinAgent PowerShell Module is Installed." -ForegroundColor Green
-    $PuppetVersion = Invoke-Expression -Command "puppet --version" -ErrorVariable $VersionError
-    If ($PuppetVersion) { Write-Host "Puppet Enterprise $PuppetVersion is installed." } else { Write-Host "Puppet Enterprise is not installed." }
+	Write-Host "PE WinAgent PowerShell Module $ModuleVersion is installed." -ForegroundColor Green
+    try {
+      $PuppetVersion = Invoke-Expression -Command "puppet --version"
+      Write-Host "Puppet Agent Version $PuppetVersion is installed."
+    } catch {
+      Write-Host "Puppet Agent is not installed."
+    }
 }

--- a/files/PuppetAgent.psm1
+++ b/files/PuppetAgent.psm1
@@ -5,9 +5,9 @@ Function Install-PuppetLocal {
 	  [Switch]$Remote,
 	  [String]$ComputerList,
 	  [Parameter(mandatory=$true)][String]$Master,
-      [String]$CertName,
+    [String]$CertName,
 	  [String]$CAServer = $Master,
-      [String]$Temp = "C:\Temp"
+    [String]$Temp = "C:\Temp"
 	)
 
   If (!(Test-Path $Temp)) { New-Item -Type Directory -Path $Temp -Force}
@@ -26,7 +26,12 @@ Function Install-PuppetLocal {
     Invoke-WebRequest $uri -Outfile $Temp\install.ps1 -ErrorAction Ignore
 
   Write-Host "Running Puppet Enterprise installation script on $env:COMPUTERNAME..."
-  Invoke-Expression "$Temp\install.ps1 -temp $Temp"
+  $params = @{
+    Temp = $Temp
+  }
+  If ($CAServer) { $params += @{ CAServer = $CAServer } }
+  If ($CertName) { $params += @{ CertName = $CertName } }
+  Invoke-Expression "$Temp\install.ps1 @params"
 }
 
 
@@ -85,9 +90,9 @@ Function Install-Puppet {
 	  [Switch]$Remote,
 	  [String]$ComputerList,
 	  [Parameter(mandatory=$true)][String]$Master,
-      [String]$CertName,
+    [String]$CertName,
 	  [String]$CAServer = $Master,
-      [String]$Temp = "C:\Temp"
+    [String]$Temp = "C:\Temp"
 	)
 
 # Default to Local installation if not otherwise specified

--- a/files/PuppetAgent.psm1
+++ b/files/PuppetAgent.psm1
@@ -1,15 +1,29 @@
 #PuppetAgent.psm1
 Function Install-PuppetLocal {
-  Param($puppetopts)
-  If (!(Test-Path $Temp)) { New-Item -Type Directory -Path $Temp -Force}
-  # Configure .NET Object to bypass self signed certificate for this session.
-  [System.Net.ServicePointManager]::ServerCertificateValidationCallback={$true}
-  $uri = "https://$Master`:8140/packages/current/install.ps1"
-  $obj = New-Object System.Net.WebClient
-  $link = $obj.DownloadString($uri)
+	Param(
+	  [Switch]$Local,
+	  [Switch]$Remote,
+	  [String]$ComputerList,
+	  [Parameter(mandatory=$true)][String]$Master,
+      [String]$CertName,
+	  [String]$CAServer = $Master,
+      [String]$Temp = "C:\Temp"
+	)
 
-  Write-Host "Getting installation script from Puppetmaster on $env:COMPUTERNAME..."
-  Invoke-WebRequest $uri -Outfile $Temp\install.ps1
+  If (!(Test-Path $Temp)) { New-Item -Type Directory -Path $Temp -Force}
+
+  Trap {
+    Write-Host $_.Exception.Message -ForegroundColor Red
+    Break
+  }
+
+    # Configure .NET Object to bypass self signed certificate for this session.
+    [System.Net.ServicePointManager]::ServerCertificateValidationCallback={$true}
+    $uri = "https://$Master`:8140/packages/current/install.ps1"
+    $obj = New-Object System.Net.WebClient
+    $link = $obj.DownloadString($uri)
+    Write-Host "Getting installation script from Puppetmaster on $env:COMPUTERNAME..."
+    Invoke-WebRequest $uri -Outfile $Temp\install.ps1 -ErrorAction Ignore
 
   Write-Host "Running Puppet Enterprise installation script on $env:COMPUTERNAME..."
   Invoke-Expression "$Temp\install.ps1 -temp $Temp"
@@ -27,6 +41,11 @@ Param (
     Master = $Master
     Temp = $Temp
     ComputerList = $ComputerList
+  }
+
+  Trap {
+    Write-Host $_.Exception.Message -ForegroundColor Red
+    Break
   }
 
   If ((Test-Path $ComputerList)) {
@@ -56,7 +75,7 @@ Param (
     Invoke-WebRequest $uri -Outfile $Temp\install.ps1
 
     Write-Host "Running Puppet Enterprise installer script on $env:COMPUTERNAME..."
-    Invoke-Expression "$Temp\install.ps1 -temp $Temp"
+    Invoke-Expression "$Temp\install.ps1 -temp $Temp" 
   } -ArgumentList $puppetopts
 }
 
@@ -71,24 +90,48 @@ Function Install-Puppet {
       [String]$Temp = "C:\Temp"
 	)
 
-    If (!($Local) -and !($Remote)) { $Local = $true }
-	If (($Local) -and ($Remote)) { 
+# Default to Local installation if not otherwise specified
+    If (!($Local) -And !($Remote)) { $Local = $true }
+
+# Bad form, kill the script if both options are given.
+	If (($Local) -And ($Remote)) { 
 	  "Don't be greedy.  There can only be one.  Remote or Local.  Decide." | Write-Host -ForegroundColor Red
-	  break
-	} elseif ($Local) {
-	    Install-PuppetLocal -Master $Master -Temp $Temp
-	} elseif ($Remote) {
-        If (!($ComputerList)) { 
-            "You must specifcy ComputerList or server name for remote install.  Exiting!" | Write-Host -ForegroundColor Red
-            break
-        }
-        Install-PuppetRemote -Master $Master -Temp $Temp -ComputerList $ComputerList 
+	  Break
+	} 
+
+# Local Installation
+    If ($Local -And !($Remote)) {
+      $params = @{
+        Master = $Master
+        Temp   = $Temp
+      }
+      
+# Add CA and CertName if specified
+      If ($CertName) { $params += @{ CertName = $CertName } }
+      If ($CAServer) { $params += @{ CAServer = $CAServer } }
+
+      Install-PuppetLocal @params
+	} 
+
+# Remote Installation
+    If ($Remote -And !($Local)) {
+      If (!($ComputerList)) { 
+        "You must specifcy ComputerList or server name for remote install.  Exiting!" | Write-Host -ForegroundColor Red
+        Break
+      }
+
+      $params = @{
+        Master       = $Master
+        Temp         = $Temp
+        ComputerList = $ComputerList
+      }
+
+      Install-PuppetRemote $params 
     }
 }
-Function Uninstall-Puppet {}
-Function Get-Puppet {
-	Invoke-Command -ScriptBlock { $puppetVersion = puppet --version; $puppetVersion | Write-Host -ForegroundColor Green }
-}
-function Test-Puppet {
-	Write-Host "I am a Jedi" -ForegroundColor Green
+
+function Test-PuppetInstall {
+	Write-Host "PE WinAgent PowerShell Module is Installed." -ForegroundColor Green
+    $PuppetVersion = Invoke-Expression -Command "puppet --version" -ErrorVariable $VersionError
+    If ($PuppetVersion) { Write-Host "Puppet Enterprise $PuppetVersion is installed." } else { Write-Host "Puppet Enterprise is not installed." }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,7 +17,11 @@ class pe_winagent(
     $s3_url      = "${s3_link}/${s3_path}/${msi}"
     $puppet_bat  = "${puppet_root}\\Puppet\\bin\\puppet.bat"
   } else {
-    $msi        = "puppet-enterprise-${::pe_build}-x64.msi"
+   if $::pe_build =~ /^"3.3"/ {
+      $msi = "puppet-enterprise-${::pe_build}.msi"
+    } else {
+      $msi = "puppet-enterprise-${::pe_build}-x64.msi"
+    }
     $s3_path    = "pe-builds/released/${::pe_build}"
     $s3_url     = "${s3_link}/pe-builds/released/${::pe_build}/${msi}"
     $puppet_bat = "${puppet_root}\\Puppet Enterprise\\bin\\puppet.bat"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,1 @@
+require 'puppetlabs_spec_helper/puppetlabs_spec_helper'

--- a/templates/install.ps1.erb
+++ b/templates/install.ps1.erb
@@ -21,6 +21,10 @@ function downloadPuppet {
 }
 
 function installPuppet {
+  Param(
+    [String]$CertName,
+    [String]$CAServer
+  )
   $install = "$temp\$package"
   $opts = @("/qn")
   If ($CAServer) { $opts += "PUPPET_CA_SERVER=$CAServer "}
@@ -47,7 +51,10 @@ function configurePuppet {
 }
 
 downloadPuppet
-installPuppet
+$params = @{}
+If ($CAServer) { $params += @{ CAServer = $CAServer }
+If ($CertName) { $params += @{ CertName = $CertName }
+installPuppet @params
 validateInstall
 configurePuppet
 

--- a/templates/install.ps1.erb
+++ b/templates/install.ps1.erb
@@ -1,7 +1,7 @@
 Param(
   [string]$temp = 'c:\temp\puppet',
   [String]$CertName,
-	[String]$CAServer = $Master,
+	[String]$CAServer = $Master
 )
 
 $master = "<%= @puppetserver %>"

--- a/templates/install.ps1.erb
+++ b/templates/install.ps1.erb
@@ -21,12 +21,8 @@ function downloadPuppet {
 }
 
 function installPuppet {
-  Param(
-    [String]$CertName,
-    [String]$CAServer
-  )
   $install = "$temp\$package"
-  $opts = @("/qn")
+  $opts = @()
   If ($CAServer) { $opts += "PUPPET_CA_SERVER=$CAServer "}
   If ($CertName) { $opts += "PUPPET_AGENT_CERTNAME=$CertName "}
   Write-Host "Installing Puppet Enterprise <%= @pe_build %> on $env:COMPUTERNAME..."
@@ -45,17 +41,24 @@ function validateInstall {
 
 function configurePuppet {
   Write-Host "Configuring Puppet Enterprise <%= @pe_build %> on $env:COMPUTERNAME..."
+  If ($CertName) {
+    Invoke-Command -ScriptBlock { cmd.exe /c $puppet config set certname $CertName --section main }
+  }
   Invoke-Command -ScriptBlock { cmd.exe /c $puppet config set server $master --section main }
   Invoke-Command -ScriptBlock { cmd.exe /c $puppet config set ca_server $ca --section main }
   Invoke-Command -ScriptBlock { cmd.exe /c $puppet config set archive_file_server $master --section main }
 }
 
 downloadPuppet
+
 $params = @{}
 If ($CAServer) { $params += @{ CAServer = $CAServer } }
 If ($CertName) { $params += @{ CertName = $CertName } }
+
 installPuppet @params
+
 validateInstall
+
 configurePuppet
 
 Write-Host "Installation has completed..."

--- a/templates/install.ps1.erb
+++ b/templates/install.ps1.erb
@@ -1,5 +1,5 @@
 Param(
-  [string]$temp = 'c:\temp\puppet'
+  [string]$temp = 'c:\temp\puppet',
   [String]$CertName,
 	[String]$CAServer = $Master,
 )

--- a/templates/install.ps1.erb
+++ b/templates/install.ps1.erb
@@ -1,7 +1,7 @@
 Param(
-  [string]$temp = 'c:\temp\puppet',
+  [string]$Temp,
   [String]$CertName,
-	[String]$CAServer = $Master
+	[String]$CAServer
 )
 
 $master = "<%= @puppetserver %>"
@@ -44,9 +44,13 @@ function configurePuppet {
   If ($CertName) {
     Invoke-Command -ScriptBlock { cmd.exe /c $puppet config set certname $CertName --section main }
   }
-  Invoke-Command -ScriptBlock { cmd.exe /c $puppet config set server $master --section main }
+  If ($CAServer) { 
+    Invoke-Command -ScriptBlock { cmd.exe /c $puppet config set server $CAServer --section main }
+  } else {
+    Invoke-Command -ScriptBlock { cmd.exe /c $puppet config set server $master --section main }
+  }
   Invoke-Command -ScriptBlock { cmd.exe /c $puppet config set ca_server $ca --section main }
-  Invoke-Command -ScriptBlock { cmd.exe /c $puppet config set archive_file_server $master --section main }
+  #Invoke-Command -ScriptBlock { cmd.exe /c $puppet config set archive_file_server $master --section main }
 }
 
 downloadPuppet

--- a/templates/install.ps1.erb
+++ b/templates/install.ps1.erb
@@ -1,5 +1,7 @@
 Param(
   [string]$temp = 'c:\temp\puppet'
+  [String]$CertName,
+	[String]$CAServer = $Master,
 )
 
 $master = "<%= @puppetserver %>"
@@ -20,7 +22,9 @@ function downloadPuppet {
 
 function installPuppet {
   $install = "$temp\$package"
-  $opts = "/qn"
+  $opts = @("/qn")
+  If ($CAServer) { $opts += "PUPPET_CA_SERVER=$CAServer "}
+  If ($CertName) { $opts += "PUPPET_AGENT_CERTNAME=$CertName "}
   Write-Host "Installing Puppet Enterprise <%= @pe_build %> on $env:COMPUTERNAME..."
   Start-Process $install $opts -Wait
 }

--- a/templates/install.ps1.erb
+++ b/templates/install.ps1.erb
@@ -22,7 +22,7 @@ function downloadPuppet {
 
 function installPuppet {
   $install = "$temp\$package"
-  $opts = @()
+  $opts = @("/qn")
   If ($CAServer) { $opts += "PUPPET_CA_SERVER=$CAServer "}
   If ($CertName) { $opts += "PUPPET_AGENT_CERTNAME=$CertName "}
   Write-Host "Installing Puppet Enterprise <%= @pe_build %> on $env:COMPUTERNAME..."

--- a/templates/install.ps1.erb
+++ b/templates/install.ps1.erb
@@ -52,8 +52,8 @@ function configurePuppet {
 
 downloadPuppet
 $params = @{}
-If ($CAServer) { $params += @{ CAServer = $CAServer }
-If ($CertName) { $params += @{ CertName = $CertName }
+If ($CAServer) { $params += @{ CAServer = $CAServer } }
+If ($CertName) { $params += @{ CertName = $CertName } }
 installPuppet @params
 validateInstall
 configurePuppet


### PR DESCRIPTION
- Puppet Enterprise 2016.x is supported now.
- Puppet Enterprise 3.3 is supported now.
- Fixed issue with local installation not passing `-CertName` or `-CAServer` parameters.
- Added a trap to kill the install process if the server can't be resolved or install script cannot be found.
- Renamed `Test-Puppet` to `Test-PuppetInstall`, which now returns that a) this module is here and b) if Puppet Enterprise is already installed (and what version).
- Removed the stubs for Uninstall-Puppet and Get-Puppet.
- Removed the documentation for using install.ps1 as a standalone script. That's as logical as using install.bash and copying it everywhere.
